### PR TITLE
changing pgp key for apt repository

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -19,7 +19,7 @@ class thumbor::repo {
     location    => "http://ppa.launchpad.net/thumbor/ppa/ubuntu/",
     release     => "precise",
     repos       => 'main',
-    key         => '1225313B',
+    key         => 'CBEC8F27',
     include_src => false,
   }
 


### PR DESCRIPTION
The PGP key has changed - https://launchpad.net/~thumbor/+archive/ppa

So, with current key vagrant is not able to install thumbor:

WARNING: The following packages cannot be authenticated!
  python-derpconf thumbor
E: There are problems and -y was used without --force-yes

Error: /Stage[main]/Thumbor::Install/Package[thumbor]/ensure: change from purged to present failed: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install thumbor' returned 100: Reading package lists...

This fixes the issue by changing key to the  new one
