### PR TITLE
Add pip-based installation and support for the OpenCV engine

### DIFF
--- a/files/init/thumbor-worker.conf
+++ b/files/init/thumbor-worker.conf
@@ -1,0 +1,41 @@
+description "Thumbor image manipulation service"
+author "Wichert Akkerman <wichert@wiggy.net>"
+
+stop on stopping thumbor
+
+respawn
+respawn limit 5 10
+umask 022
+
+setuid thumbor
+setgid thumbor
+
+env DAEMON=/usr/local/bin/thumbor
+
+env conffile=/etc/thumbor.conf
+env keyfile=/etc/thumbor.key
+env ip=0.0.0.0
+
+chdir /var/lib/thumbor
+
+instance $p
+
+pre-start script
+    [ -r /etc/default/thumbor ] && . /etc/default/thumbor
+    if [ "$enabled" = "0" ] && [ "$force" != "1" ] ; then
+        logger -is -t "$UPSTART_JOB" "Thumbor is disabled by /etc/default/thumbor, add force=1 to your service command"
+        stop
+        exit 0
+    fi
+    exec >"/tmp/${UPSTART_JOB}-${p}"
+    echo "ip=${ip}"
+end script
+
+script
+    . "/tmp/${UPSTART_JOB}-${p}"
+    $DAEMON -c "${conffile}" -i "${ip}" -k "${keyfile}" -p "${p}" -l debug
+end script
+
+post-start script
+    rm -f "/tmp/$UPSTART_JOB-${p}"
+end script

--- a/files/init/thumbor.conf
+++ b/files/init/thumbor.conf
@@ -1,0 +1,21 @@
+description "Thumbor image manipulation service"
+author "Wichert Akkerman <wichert@wiggy.net>"
+
+start on filesystem and runlevel [2345]
+stop on runlevel [!2345]
+
+console output
+
+env port=8888
+
+pre-start script
+    [ -r /etc/default/thumbor ] && . /etc/default/thumbor
+    if [ "$enabled" = "0" ] && [ "$force" != "1" ] ; then
+        logger -is -t "$UPSTART_JOB" "Thumbor is disabled by /etc/default/thumbor, add force=1 to your service command"
+        stop
+        exit 0
+    fi
+    for p in `echo ${port} | tr ',' ' '`; do
+        start thumbor-worker p=$p
+    done
+end script

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,18 +16,26 @@ class thumbor (
   $port='8888', 
   $ip='0.0.0.0', 
   $config = {}, 
-  $conffile = '/dev/null'
+  $conffile = '/dev/null',
+  $install_method = 'apt'
 ) {
 
     ## Modules
-    include thumbor::repo
-    include thumbor::install
     include thumbor::config
     include thumbor::service
 
     ## Ordering
-    Class['thumbor::repo']
-    -> Class['thumbor::install']
-    -> Class['thumbor::config']
-    -> Class['thumbor::service']
+    Class['thumbor::config']
+    ~> Class['thumbor::service']
+
+    if $install_method == 'apt' {
+        include thumbor::repo
+        include thumbor::install::apt
+        Class['thumbor::repo'] -> Class['thumbor::install::apt'] -> Class['thumbor::config']
+    } elsif $install_method == 'pip' {
+        include thumbor::install::pip
+        Class['thumbor::install::pip'] -> Class['thumbor::config']
+    } else {
+        fail("install_method must be 'apt' or 'pip'")
+    }
 }

--- a/manifests/install/apt.pp
+++ b/manifests/install/apt.pp
@@ -1,4 +1,4 @@
-# = Class: thumbor::install
+# = Class: thumbor::install::apt
 #
 # This module manages thumbor
 #
@@ -11,7 +11,7 @@
 # == Sample Usage:
 #
 # [Remember: No empty lines between comments and class definition]
-class thumbor::install {
+class thumbor::install::apt {
   package{ ['thumbor']:
     ensure => present
   }

--- a/manifests/install/pip.pp
+++ b/manifests/install/pip.pp
@@ -8,11 +8,19 @@ class thumbor::install::pip {
     fail("Make sure the python class also includes the python-dev package.")
   }
 
-  package { ['libwebp-dev', 'python-statsd', 'python-crypto', 'libjpeg-dev', 'libjpeg8-dev', 'libpng12-dev', 'libtiff5-dev']: }
+  package { ['libwebp-dev', 'python-statsd', 'python-crypto', 'libjpeg-dev', 'libjpeg8-dev', 'libpng12-dev', 'libtiff5-dev', 'python-numpy', 'python-opencv', 'libcurl4-openssl-dev']: }
+
+  -> python::pip { 'colour':
+      pkgname => 'colour'
+  }
 
   -> python::pip { 'thumbor':
-        pkgname => 'thumbor',
-        ensure => '5.2.1'
+      pkgname => 'thumbor',
+      ensure => '5.2.1'
+  }
+
+  -> python::pip { 'opencv-engine':
+      pkgname => 'opencv-engine'
   }
 
   file {'/etc/init/thumbor.conf':

--- a/manifests/install/pip.pp
+++ b/manifests/install/pip.pp
@@ -1,0 +1,55 @@
+class thumbor::install::pip {
+
+  if !defined(Class['python']) {
+    fail("You must include the python class first.")
+  }
+
+  if !defined(Package['python-dev']) {
+    fail("Make sure the python class also includes the python-dev package.")
+  }
+
+  package { ['libwebp-dev', 'python-statsd', 'python-crypto', 'libjpeg-dev', 'libjpeg8-dev', 'libpng12-dev', 'libtiff5-dev']: }
+
+  -> python::pip { 'thumbor':
+        pkgname => 'thumbor',
+        ensure => '5.2.1'
+  }
+
+  file {'/etc/init/thumbor.conf':
+    ensure => present,
+    owner  => root,
+    group  => root,
+    mode   => 0644,
+    source => 'puppet:///modules/thumbor/init/thumbor.conf',
+    notify => Class['thumbor::service'],
+  }
+
+  file {'/etc/init/thumbor-worker.conf':
+    ensure => present,
+    owner  => root,
+    group  => root,
+    mode   => 0644,
+    source => 'puppet:///modules/thumbor/init/thumbor-worker.conf',
+    notify => Class['thumbor::service'],
+  }
+
+  group { 'thumbor':
+    system => true,
+    ensure => present
+  }
+
+  user { 'thumbor':
+    system => true,
+    gid => 'thumbor',
+    home => '/var/lib/thumbor',
+    require => Group['thumbor']
+  }
+
+  file { '/var/lib/thumbor':
+    ensure => directory,
+    owner => 'thumbor',
+    group => 'thumbor',
+    mode => 0755
+  }
+ 
+}

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -17,6 +17,7 @@ class thumbor::service {
                     '/etc/thumbor.key',
                     '/etc/default/thumbor'],
     ensure  => running,
+    enable  => true,
     subscribe => File['/etc/thumbor.conf',
                     '/etc/thumbor.key',
                     '/etc/default/thumbor'],


### PR DESCRIPTION
Here are some changes I made to successfully install Thumbor 5.2.1 via `pip`.

The `apt`-based installation using the Thumbor PPA gets an outdated version, seems the PPA is not maintained anymore (?).

This also includes the necessary dependencies to setup the opencv-engine for face detection. 

Note that the opencv-engine seems not to work with Thumbor 6 (https://github.com/thumbor/thumbor/commit/c19e2b0e3ad11334f7d94aa9054a6a84246a758d#commitcomment-14364435) and does also not support WebP (requires OpenCV 3).
